### PR TITLE
Add manifest file for deploying to PaaS

### DIFF
--- a/manifest.yml.tmpl
+++ b/manifest.yml.tmpl
@@ -1,0 +1,11 @@
+---
+applications:
+  - name: build-learn-stub-op
+    stack: cflinuxfs3
+    memory: 1G
+    buildpacks:
+      - java_buildpack
+    env:
+      REDIS_URI: redis-service
+    services:
+      - redis-service


### PR DESCRIPTION
Manually building the .jar and binding the redis service will still need to be done.

https://trello.com/c/KRvDqBp5/49-make-stub-op-app-available-on-paas